### PR TITLE
Use pgrep to check sshd

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -65,12 +65,11 @@ spec:
           imagePullPolicy: {{ .Values.rsync.image.pullPolicy }}
           ports:
             - containerPort: 22
-          livenessProbe:
-            tcpSocket:
-              port: 22
           readinessProbe:
-            tcpSocket:
-              port: 22
+            exec:
+              command:
+              - pgrep
+              - sshd
           envFrom:
             - configMapRef:
                 name: rsync-ssh-users


### PR DESCRIPTION
Use a command instead of probing port 22 to avoid spurious sshd log messages. Get rid of liveness probe for the similar reasons- once the initialisation steps are done and sshd is running that is sufficient to know the container is working, if sshd fails the container should automatically die since it is PID 1.